### PR TITLE
Add theme support for Webstories

### DIFF
--- a/header.php
+++ b/header.php
@@ -29,6 +29,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <body <?php astra_schema_body(); ?> <?php body_class(); ?>>
 
+<?php if( function_exists('web_stories_customizer') ) web_stories_customizer(); ?>
+
 <?php astra_body_top(); ?>
 <?php wp_body_open(); ?>
 <div 

--- a/inc/class-astra-after-setup-theme.php
+++ b/inc/class-astra-after-setup-theme.php
@@ -175,6 +175,9 @@ if ( ! class_exists( 'Astra_After_Setup_Theme' ) ) {
 				);
 			}
 
+			// Enable Webstories.
+			add_theme_support( 'web-stories-options' );
+
 		}
 
 		/**


### PR DESCRIPTION
### Description
Adds theme support for the Webstories. The webstories can be enabled via Customizer.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
